### PR TITLE
feat: only lint the list items

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,18 +10,30 @@ module.exports = rule(
 function processor(tree, file) {
   const links = new Map();
 
-  visit(tree, 'link', node => {
-    const url = node.url.startsWith('#') ? node.url : normalizeUrl(node.url, {
-      removeDirectoryIndex: true,
-      stripHash: true,
-      stripProtocol: true,
-      // removeQueryParameters: [/\.*/i]
-    });
+  visit(tree, 'list', list => {
+    for (const listItem of list.children) {
+      const [paragraph] = listItem.children
+      if (!paragraph || paragraph.type !== 'paragraph' || paragraph.children.length === 0) {
+        continue
+      }
 
-    if (links.has(url)) {
-      links.get(url).push(node)
-    } else {
-      links.set(url, [node])
+      const [node] = paragraph.children
+      if (node.type === 'text') {
+        continue
+      }
+
+      const url = node.url.startsWith('#') ? node.url : normalizeUrl(node.url, {
+        removeDirectoryIndex: true,
+        stripHash: true,
+        stripProtocol: true,
+        // removeQueryParameters: [/\.*/i]
+      })
+
+      if (links.has(url)) {
+        links.get(url).push(node)
+      } else {
+        links.set(url, [node])
+      }
     }
   })
 

--- a/test/test.js
+++ b/test/test.js
@@ -16,6 +16,9 @@ const nok = `![img](./logo)
 const ok = `- [puper-link-1](http://link-1)
 - [puper-link-1](http://link-2)`;
 
+const okInDesc = `- [puper-link-1](http://link-1) - [puper-link-1](http://link-1)
+- [puper-link-2](http://link-2) - Forked [puper-link-1](http://link-1)`;
+
 test('remark-lint-double-link valid', t => {
   t.deepEqual(
     processor.processSync(ok).messages.map(String),
@@ -24,15 +27,21 @@ test('remark-lint-double-link valid', t => {
   );
 });
 
+test('remark-lint-double-link valid for descriptions', t => {
+  t.deepEqual(
+    processor.processSync(okInDesc).messages.map(String),
+    [],
+    'should work on valid fixtures ignoring descriptions'
+  );
+});
+
 test('remark-lint-double-link invalid', t => {
   t.deepEqual(
     processor.processSync(nok).messages.map(String),
     [
-      '2:1-2:30: http://link-1',
-      '3:3-3:32: http://link-1',
       '6:3-6:44: #appimage-discovery',
       '7:3-7:44: #appimage-discovery',
     ],
-    'should work on valid fixtures'
+    'should work on invalid fixtures'
   );
 });


### PR DESCRIPTION
Fix https://github.com/sindresorhus/awesome-lint/issues/133.

- main logic to find list items keeps the same with `awesome-lint/rules/list-item.js`
- fix a typo in tests
- **BREAKING** update tests to ignore double-links not in list items